### PR TITLE
[#10] Slugify field names before sending to BigQuery

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 six
 jsontableschema
 google-api-python-client
+python-slugify
 git+git://github.com/okfn/tabulator-py.git


### PR DESCRIPTION
BigQuery has specific requirements for the field names:

> [Required] The field name. The name must contain only letters (a-z, A-Z),
> numbers (0-9), or underscores (_), and must start with a letter or
> underscore. The maximum length is 128 characters.
> https://cloud.google.com/bigquery/docs/reference/v2/tables

So, if the field names aren't compatible with these requirements, we have to
convert them before sending to BigQuery.
